### PR TITLE
Remove duplicate linter definitions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem 'j2119', '>=0.1.0'
+gem 'rspec', '~> 3.8.0'

--- a/lib/statelint.rb
+++ b/lib/statelint.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
 require 'j2119'
 require 'statelint/state_node'
 

--- a/spec/state_node_spec.rb
+++ b/spec/state_node_spec.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
 require 'json'
 require 'statelint/state_node'
 

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -29,13 +29,11 @@ describe StateMachineLint do
   it 'should reject empty ErrorEquals clauses' do
     j = File.read "test/empty-error-equals-on-catch.json"
     linter = StateMachineLint::Linter.new
-    linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(1)
     expect (problems[0].include?('non-empty required'))
-    
+
     j = File.read "test/empty-error-equals-on-retry.json"
-    linter = StateMachineLint::Linter.new
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
     expect(problems.size).to eq(1)

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -12,7 +12,6 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(__dir__)}/../lib")
 require 'json'
 require 'statelint'
 
@@ -71,7 +70,6 @@ describe StateMachineLint do
     expect(problems.size).to eq(1)
     expect (problems[0].include?('"ResultPath"'))
 
-
     j = File.read "test/succeed-with-resultpath.json"
     linter = StateMachineLint::Linter.new
     problems = linter.validate(j)
@@ -89,7 +87,5 @@ describe StateMachineLint do
     problems = linter.validate(j)
     problems.each { |p| puts "P: #{p}" }
     expect(problems.size).to eq(0)
-    
   end
-
 end

--- a/spec/statelint_spec.rb
+++ b/spec/statelint_spec.rb
@@ -12,7 +12,7 @@
 # permissions and limitations under the License.
 #!/usr/bin/env ruby
 
-$:.unshift("#{File.expand_path(File.dirname(__FILE__))}/../lib")
+$:.unshift("#{File.expand_path(__dir__)}/../lib")
 require 'json'
 require 'statelint'
 


### PR DESCRIPTION
I read your spec file today and saw that `linter` was defined twice in quick succession, and it didn't need to be from what I could tell. I've removed these.

At the top of your tests you're also modifying `$:`, the Ruby loadpath. This will add `lib` twice to the loadpath (once for each test) and it is unnecessary because RSpec automatically adds the `lib` path to your loadpath during the test run.

Similarly, the loadpath modification in `lib/statelint.rb` is not required either. Bundler (and RubyGems, iirc) will add the `lib` directory to the loadpath for you. You're doubling up here again.

I also noticed that you were missing `rspec` from your Gemfile. This should be added to the `Gemfile`, as its a gem that is required to work on this project. I added it for you.

I've also cleaned up a few extra spaces / lines that weren't required.